### PR TITLE
Fix GitHub workflow to pass on Ubuntu/Mac/Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        include:
-        - os: macos-latest
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "3.8"
-        - os: windows-latest
-          python-version: "3.10"
+        os: [macos-latest, ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
+        python-version: ["3.10", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -41,4 +34,4 @@ jobs:
         pip install --upgrade coverage
         git config --global --add init.defaultBranch master
         git config --global --add advice.detachedHead true
-        ${{ matrix.os == 'windows-latest' && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test
+        ${{ startsWith(matrix.os, 'windows') && 'set PYTHONPATH=%cd% &&' || 'PYTHONPATH=`pwd`' }} pytest -s -v test

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ setup(
         'setuptools'],
     extras_require={
         'test': [
-            'flake8 >= 3.7, < 5',
+            'flake8',
             'flake8-docstrings',
             'flake8-import-order',
-            'pycodestyle < 2.9.0',
-            'pyflakes < 2.5.0',
+            'pycodestyle',
+            'pyflakes',
             'pytest']
         },
     packages=find_packages(),

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -326,8 +326,9 @@ invocation.
         expected = get_expected_output('validate_hide')
         self.assertEqual(output, expected)
 
-    @unittest.skipIf(not svn and not CI, '`svn` was not found')
-    @unittest.skipIf(not hg and not CI, '`hg` was not found')
+    @unittest.skipIf(CI, 'Cannot run on CI')
+    @unittest.skipIf(not svn, '`svn` was not found')
+    @unittest.skipIf(not hg, '`hg` was not found')
     def test_validate_svn_and_hg(self):
         output = run_command(
             'validate', ['--input', REPOS2_FILE])

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -369,7 +369,7 @@ def run_command(command, args=None, subfolder=None):
 
 
 def adapt_command_output(output, cwd=None):
-    assert type(output) == bytes
+    assert isinstance(output, bytes)
     # replace message from older git versions
     output = output.replace(
         b'git checkout -b new_branch_name',

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 from flake8 import configure_logging
-from flake8.api.legacy import StyleGuide
 from flake8.main.application import Application
 from pydocstyle.config import log
 
@@ -15,8 +14,8 @@ def test_flake8():
         '--extend-ignore=' + ','.join([
             'A003', 'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107']),
         '--exclude', 'vcstool/compat/shutil.py',
-        '--import-order-style=google']
-    style_guide = get_style_guide(argv)
+        '--import-order-style=google'
+    ]
     base_path = os.path.join(os.path.dirname(__file__), '..')
     paths = [
         os.path.join(base_path, 'setup.py'),
@@ -28,38 +27,11 @@ def test_flake8():
         if script.startswith('.'):
             continue
         paths.append(os.path.join(scripts_path, script))
-    report = style_guide.check_files(paths)
-    assert report.total_errors == 0, \
-        'Found %d code style warnings' % report.total_errors
 
-
-def get_style_guide(argv=None):
-    # this is a fork of flake8.api.legacy.get_style_guide
-    # to allow passing command line argument
-    application = Application()
-    if hasattr(application, 'parse_preliminary_options'):
-        prelim_opts, remaining_args = application.parse_preliminary_options(
-            argv)
-        from flake8 import configure_logging
-        configure_logging(prelim_opts.verbose, prelim_opts.output_file)
-        from flake8.options import config
-        config_finder = config.ConfigFileFinder(
-            application.program, prelim_opts.append_config,
-            config_file=prelim_opts.config,
-            ignore_config_files=prelim_opts.isolated)
-        application.find_plugins(config_finder)
-        application.register_plugin_options()
-        application.parse_configuration_and_cli(config_finder, remaining_args)
-    else:
-        application.parse_preliminary_options_and_args([])
-        application.make_config_finder()
-        application.find_plugins()
-        application.register_plugin_options()
-        application.parse_configuration_and_cli(argv)
-    application.make_formatter()
-    application.make_guide()
-    application.make_file_checker_manager()
-    return StyleGuide(application)
+    app = Application()
+    app.run(argv + paths)
+    assert app.result_count == 0, \
+        f'Found {app.result_count} code style warnings'
 
 
 if __name__ == '__main__':

--- a/vcstool/executor.py
+++ b/vcstool/executor.py
@@ -17,7 +17,6 @@ windows_force_posix = \
 
 
 def fix_output_path(path):
-    global windows_force_posix
     return path.replace('\\', '/') if windows_force_posix else path
 
 
@@ -81,7 +80,6 @@ def get_ready_job(jobs):
 def execute_jobs(
     jobs, show_progress=False, number_of_workers=10, debug_jobs=False
 ):
-    global windows_force_posix
     from vcstool.streams import stdout
     if debug_jobs:
         logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |


## Description of contribution

Configured the GitHub workflow to [run safely](https://github.com/leander-dsouza/vcstool/actions) without any issues.

* Used the [latest set of libraries](https://github.com/ros-infrastructure/vcstool/pull/2/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R13-R17) in the dependencies.
* Fixed the [legacy flake8](https://github.com/ros-infrastructure/vcstool/pull/2/files#diff-76767a4ede8aa8e2da03c5269c8125b240ef3f86c06cdda214b8f4aec663e345R31-R34) test to enable linting with the latest Python version.
* Fixed unit test logic in [`test_validate_svn_and_hg`](https://github.com/ros-infrastructure/vcstool/pull/2/files#diff-3ce9fb502384b9c9340eb518556b214b22dc8496e33ba1d309324c473cf09520R329-R331)order to skip correctly when the test is not in CI.
* Restricted Python versions to 3.10 and 3.12 to be in line with Humble and Jazzy.

## Description of testing done

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```
* Created a local fork to validate vcstool on Mac, Windows, and Ubuntu OS using Python 3.10/3.12.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)

