### PR TITLE
Add python 3.7 and 3.8 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
         python-version: ["3.10", "3.12"]
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.7"
+          - os: ubuntu-22.04
+            python-version: "3.8"
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
> [!NOTE]  
> #4 needs to be merged prior to the review of this PR.

## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

## Description of contribution

* Added Python 3.7 and Python 3.8 to the CI to support running on Debian Buster and Ubuntu Focal.

* However, the additional versions cannot target Ubuntu 20.04, as the GitHub runner is [deprecated](https://github.com/actions/runner-images/issues/11101).

* In addition, these versions cannot run on all the operating systems mentioned in the matrix CI, as these releases are out of the bounds of support as described [here](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json).
    
## Description of testing done

* Ran `pytest` locally to ensure all the unit and linting tests pass:

   ```bash
   pytest -s -v test
   ```
* Created a local fork to validate green CI.

Signed-off-by: Leander Stephen Desouza [leanderdsouza1234@gmail.com](mailto:leanderdsouza1234@gmail.com)