### PR TITLE
Added ignores for pytest cache, bytecode, and virtual environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build
 deb_dist
 dist
 vcstool.egg-info
+.pytest_cache
+__pycache__
+venv


### PR DESCRIPTION
## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

## Description of contribution

Added gitignores for the following files:
   * Pytest cache - `.pytest_cache`
   * Python bytecode - `__pycache__`
   * Virtual environment - `venv/`

This is mainly motivated by the enforcement of [PEP 668](https://peps.python.org/pep-0668/) in Ubuntu 24.04. Hence, the ignores to `venv/` prove to be useful when developing in isolation.
